### PR TITLE
Add additional functions

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -52,6 +52,19 @@ def xy(lng, lat, truncate=False):
     return x, y
 
 
+def lnglat(x, y, pi=3.141592653589793):
+    """Returns the (lng, lat) in WGS84 Datum"""
+
+    origin_shift = 2 * pi * 6378137 / 2.0
+    osd = origin_shift / 180.0
+    lng = x / osd
+    lat = y / osd
+    lat = (2 * math.atan(
+        math.exp(lat * pi / 180.0)
+    ) - (pi / 2.0)) / (pi / 180.0)
+    return lng, lat
+
+
 def tile(lng, lat, zoom, truncate=False):
     """Returns the (x, y, z) tile"""
     if truncate:

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -156,6 +156,11 @@ def bounding_tile(*bbox, **kwds):
     return Tile(x, y, z)
 
 
+def resolution(zoom):
+    initial_resolution = 20037508.342789244 * 2 / 256
+    return initial_resolution / (2 ** zoom)
+
+
 def _getBboxZoom(*bbox):
     MAX_ZOOM = 28
     for z in range(0, MAX_ZOOM):

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -161,6 +161,26 @@ def resolution(zoom):
     return initial_resolution / (2 ** zoom)
 
 
+def bounds_for_viewport(lng, lat, width, height, resolution):
+    """Return (lng, lat) bounding box for specified viewport."""
+
+    half_w_deg = (width * resolution) / 2.0
+    half_h_deg = (height * resolution) / 2.0
+
+    x, y = xy(lng, lat)
+
+    return (
+        lnglat(
+            x - half_w_deg,
+            y + half_h_deg,
+        ),
+        lnglat(
+            x + half_w_deg,
+            y - half_h_deg,
+        )
+    )
+
+
 def _getBboxZoom(*bbox):
     MAX_ZOOM = 28
     for z in range(0, MAX_ZOOM):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -33,6 +33,14 @@ def test_xy():
         assert round(a-b, 7) == 0
 
 
+def test_lnglat():
+    xy = (-1017529.7205322663, 7044436.526761846)
+    lnglat = mercantile.lnglat(*xy)
+    expected = (-9.140625, 53.33087298301705)
+    for a, b in zip(expected, lnglat):
+        assert round(a-b, 7) == 0
+
+
 def test_tile():
     tile = mercantile.tile(20.6852, 40.1222, 9)
     expected = (285, 193)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -33,6 +33,12 @@ def test_xy():
         assert round(a-b, 7) == 0
 
 
+def test_resolution():
+    resolution = mercantile.resolution(0)
+    initial_resolution = 20037508.342789244 * 2 / 256
+    assert resolution == initial_resolution
+
+
 def test_lnglat():
     xy = (-1017529.7205322663, 7044436.526761846)
     lnglat = mercantile.lnglat(*xy)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -39,6 +39,16 @@ def test_resolution():
     assert resolution == initial_resolution
 
 
+def test_bounds_for_viewport():
+    initial_resolution = 20037508.342789244 * 2 / 256
+    bounds = mercantile.bounds_for_viewport(
+        0, 45, 256, 256, initial_resolution
+        )
+    assert bounds == (
+        (-180.0, 87.94905406387923), (180.0, -78.08802742575901)
+    )
+
+
 def test_lnglat():
     xy = (-1017529.7205322663, 7044436.526761846)
     lnglat = mercantile.lnglat(*xy)


### PR DESCRIPTION
I needed a ``bounds_for_viewport()`` function to help me get the bounding box that matches a particular screen map viewport, e.g. 640 x 480 with some center and zoom level.