### PR TITLE
Consistent interface for tile arguments

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -14,8 +14,11 @@ LngLat = namedtuple('LngLat', ['lng', 'lat'])
 LngLatBbox = namedtuple('LngLatBbox', ['west', 'south', 'east', 'north'])
 
 
-def ul(xtile, ytile, zoom):
+def ul(*tile):
     """Returns the upper left (lon, lat) of a tile"""
+    if len(tile) == 1:
+        tile = tile[0]
+    xtile, ytile, zoom = tile
     n = 2.0 ** zoom
     lon_deg = xtile / n * 360.0 - 180.0
     lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * ytile / n)))
@@ -23,8 +26,11 @@ def ul(xtile, ytile, zoom):
     return LngLat(lon_deg, lat_deg)
 
 
-def bounds(xtile, ytile, zoom):
+def bounds(*tile):
     """Returns the (lon, lat) bounding box of a tile"""
+    if len(tile) == 1:
+        tile = tile[0]
+    xtile, ytile, zoom = tile
     a = ul(xtile, ytile, zoom)
     b = ul(xtile+1, ytile+1, zoom)
     return LngLatBbox(a[0], b[1], b[0], a[1])

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -1,18 +1,30 @@
+import pytest
+
 import mercantile
 
 
-def test_ul():
+@pytest.mark.parametrize('args', [
+   (486, 332, 10),
+   [(486, 332, 10)],
+   [mercantile.Tile(486, 332, 10)],
+])
+def test_ul(args):
     expected = (-9.140625, 53.33087298301705)
-    lnglat = mercantile.ul(486, 332, 10)
+    lnglat = mercantile.ul(*args)
     for a, b in zip(expected, lnglat):
         assert round(a-b, 7) == 0
     assert lnglat[0] == lnglat.lng
     assert lnglat[1] == lnglat.lat
 
 
-def test_bbox():
+@pytest.mark.parametrize('args', [
+   (486, 332, 10),
+   [(486, 332, 10)],
+   [mercantile.Tile(486, 332, 10)],
+])
+def test_bbox(args):
     expected = (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)
-    bbox = mercantile.bounds(486, 332, 10)
+    bbox = mercantile.bounds(*args)
     for a, b in zip(expected, bbox):
         assert round(a-b, 7) == 0
     assert bbox.west == bbox[0]


### PR DESCRIPTION
@sgillies @perrygeo Hoped to catch this one before the pending release. Since `parent()`, `children()` and `quadkey()` (from #51) have similar interface for specifying a tile as a function argument, I figure it makes sense for `ul` and `bounds` to allow the same.

I guess if there many more of these it would make sense to have a common decorator.

Make ul() and bounds() have the same interface as parent, children, and
quadkey.

```
def f(*tile):
    if len(tile) == 1:
        tile = tile[0]
    xtile, ytile, zoom = tile
    ...
```