### PR TITLE
Added function to calculate Spherical Mercator bounds for a tile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+rasterio/_*.html
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IDE's etc.
+.idea/
+venv/
+venv2/
+
+# vim
+.*.swp

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,3 +7,4 @@ Patrick M Young <patrick.mckendree.young@gmail.com>
 Amit Kapadia <akapad@gmail.com>
 Stefano Costa <steko@iosa.it>
 Jacob Wasserman <jwasserman@gmail.com>
+Brendan Ward <bcward@consbio.org>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changes
 =======
 
+0.10.0 (TODO)
+-------------
+- New feature: ``xy_bounds()`` to get Spherical Mercator bounds for tile
+
 0.9.0 (2016-05-20)
 ------------------
 - Refactoring: new ``normalize_input()`` and ``iterl_lines()`` functions for

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Sean C. Gillies
+Copyright (c) 2014-2017, Sean C. Gillies
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,8 @@ coordinates.
     LngLatBbox(west=-9.140625, south=53.12040528310657, east=-8.7890625, north=53.33087298301705)
     >>> mercantile.xy(*mercantile.ul(486, 332, 10))
     (-1017529.7205322663, 7044436.526761846)
+    >> mercantile.xy_bounds(486, 332, 10)
+    Bbox(left=-1017529.7205322663, bottom=7005300.768279833, right=-978393.962050256, top=7044436.526761846)
     >>> mercantile.tile(*mercantile.ul(486, 332, 10) + (10,))
     Tile(x=486, y=332, z=10)
     >>> mercantile.quadkey(486, 332, 10)

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -12,6 +12,7 @@ __version__ = '0.9.0'
 Tile = namedtuple('Tile', ['x', 'y', 'z'])
 LngLat = namedtuple('LngLat', ['lng', 'lat'])
 LngLatBbox = namedtuple('LngLatBbox', ['west', 'south', 'east', 'north'])
+Bbox = namedtuple('Bbox', ['left', 'bottom', 'right', 'top'])
 
 
 def ul(*tile):
@@ -56,6 +57,16 @@ def xy(lng, lat, truncate=False):
     y = 6378137.0 * math.log(
         math.tan((math.pi * 0.25) + (0.5 * math.radians(lat))))
     return x, y
+
+
+def xy_bounds(*tile):
+    """Returns the Spherical Mercator bounding box of a tile"""
+    if len(tile) == 1:
+        tile = tile[0]
+    xtile, ytile, zoom = tile
+    left, top = xy(*ul(xtile, ytile, zoom))
+    right, bottom = xy(*ul(xtile + 1, ytile + 1, zoom))
+    return Bbox(left, bottom, right, top)
 
 
 def tile(lng, lat, zoom, truncate=False):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -48,6 +48,19 @@ def test_xy_truncate():
     assert mercantile.xy(-181.0, 0.0, truncate=True) == mercantile.xy(-180.0, 0.0)
 
 
+@pytest.mark.parametrize('args', [
+    (486, 332, 10),
+    [(486, 332, 10)],
+    [mercantile.Tile(486, 332, 10)]])
+def test_xy_bounds(args):
+    expected = (-1017529.7205322663, 7005300.768279833,
+                -978393.962050256, 7044436.526761846)
+    bounds = mercantile.xy_bounds(*args)
+
+    for a, b in zip(expected, bounds):
+        assert round(a - b, 7) == 0
+
+
 def test_tile():
     tile = mercantile.tile(20.6852, 40.1222, 9)
     expected = (285, 193)


### PR DESCRIPTION
`mercantile.xy_bounds(486, 332, 10)` ==>

`Bbox(left=-1017529.7205322663, bottom=7005300.768279833, right=-978393.962050256, top=7044436.526761846)`

Could help make extracting tile bounds for `rasterio`'s shiny new `WarpedVRT` easier... (per comments in https://github.com/mapbox/rasterio/pull/1029)

Note: the date and any other changes for version 0.10.0 will need to be updated; I just stubbed that out here.

Also added `.gitignore` since it was missing.