### PR TITLE
Correct transformation of poles coordinates

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -140,8 +140,13 @@ def xy(lng, lat, truncate=False):
     if truncate:
         lng, lat = truncate_lnglat(lng, lat)
     x = 6378137.0 * math.radians(lng)
-    y = 6378137.0 * math.log(
-        math.tan((math.pi * 0.25) + (0.5 * math.radians(lat))))
+    if lat <= -90:
+        y = float('-inf')
+    elif lat >= 90:
+        y = float('inf')
+    else:
+        y = 6378137.0 * math.log(
+            math.tan((math.pi * 0.25) + (0.5 * math.radians(lat))))
     return x, y
 
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -41,6 +41,8 @@ def test_xy():
     expected = (0.0, 0.0)
     for a, b in zip(expected, xy):
         assert round(a - b, 7) == 0
+    assert mercantile.xy(0.0, -90) == (0.0, float('-inf'))
+    assert mercantile.xy(0.0, 90) == (0.0, float('inf'))
 
 
 def test_xy_truncate():


### PR DESCRIPTION
For now xy function cannot make a correct transformation for poles coordinates.

```python
>>> import mercantile
>>> mercantile.xy(-180, 90)
(-20037508.342789244, 238107693.26496765)
>>> mercantile.xy(-180, -90)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rykov/sandbox/mercantile/mercantile/__init__.py", line 144, in xy
    math.tan((math.pi * 0.25) + (0.5 * math.radians(lat))))
ValueError: math domain error
```