### PR TITLE
Fix zoom level argument of mercantile.tiles()

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -315,7 +315,7 @@ def tiles(west, south, east, north, zooms, truncate=False):
         e = min(180.0, e)
         n = min(85.051129, n)
 
-        if not isinstance(zooms,Sequence): zooms = [zooms]
+        if not isinstance(zooms, Sequence): zooms = [zooms]
         for z in zooms:
             ll = tile(w, s, z)
             ur = tile(e, n, z)

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -315,7 +315,9 @@ def tiles(west, south, east, north, zooms, truncate=False):
         e = min(180.0, e)
         n = min(85.051129, n)
 
-        if not isinstance(zooms, Sequence): zooms = [zooms]
+        if not isinstance(zooms, Sequence):
+            zooms = [zooms]
+
         for z in zooms:
             ll = tile(w, s, z)
             ur = tile(e, n, z)

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -1,6 +1,7 @@
 """Web mercator XYZ tile utilities"""
 
 from collections import namedtuple
+from collections import Sequence
 import math
 
 
@@ -314,6 +315,7 @@ def tiles(west, south, east, north, zooms, truncate=False):
         e = min(180.0, e)
         n = min(85.051129, n)
 
+        if not isinstance(zooms,Sequence): zooms = [zooms]
         for z in zooms:
             ll = tile(w, s, z)
             ur = tile(e, n, z)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -108,9 +108,11 @@ def test_tile_truncate():
 def test_tiles():
     bounds = (-105, 39.99, -104.99, 40)
     tiles = list(mercantile.tiles(*bounds, zooms=[14]))
+    tiles_single_zoom = list(mercantile.tiles(*bounds, zooms=14))
     expect = [mercantile.Tile(x=3413, y=6202, z=14),
               mercantile.Tile(x=3413, y=6203, z=14)]
     assert sorted(tiles) == sorted(expect)
+    assert sorted(tiles_single_zoom) == sorted(expect)
 
 
 def test_tiles_truncate():

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -108,11 +108,17 @@ def test_tile_truncate():
 def test_tiles():
     bounds = (-105, 39.99, -104.99, 40)
     tiles = list(mercantile.tiles(*bounds, zooms=[14]))
-    tiles_single_zoom = list(mercantile.tiles(*bounds, zooms=14))
     expect = [mercantile.Tile(x=3413, y=6202, z=14),
               mercantile.Tile(x=3413, y=6203, z=14)]
     assert sorted(tiles) == sorted(expect)
-    assert sorted(tiles_single_zoom) == sorted(expect)
+
+
+def test_tiles_single_zoom():
+    bounds = (-105, 39.99, -104.99, 40)
+    tiles = list(mercantile.tiles(*bounds, zooms=14))
+    expect = [mercantile.Tile(x=3413, y=6202, z=14),
+              mercantile.Tile(x=3413, y=6203, z=14)]
+    assert sorted(tiles) == sorted(expect)
 
 
 def test_tiles_truncate():


### PR DESCRIPTION
Hi,
I just started using mercantile and so far I am very happy with it. I noticed that mercantile.tiles()
fails when supplied with a single integer as zoom level. While the documentation says
```
 zooms : int or sequence of int
     One or more zoom levels.
```
the code directly iterates over the ```zooms``` argument. So I wrote a little helper converting ```zooms``` into a list if needed. If this should implement the desired behaviour, feel free to merge.

   Best,
   Felix