### PR TITLE
Publish to PyPI only on tagged 3.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ after_success:
   - coveralls
 deploy:
   on:
+    repo: mapbox/mercantile
+    python: 3.6
     tags: true
   provider: pypi
   distributions: "sdist bdist_wheel"


### PR DESCRIPTION
Travis builds currently run on 2.7, 3.4, 3.5, & 3.6. The [deploy step](https://github.com/mapbox/mercantile/blob/6d3b564b47ad342a0d8ad1b64dabb270549b4f68/.travis.yml#L16)  attempts to run on each of those builds, but can only succeed for the first job to finish.

The remainder fail with an error like:
```
HTTPError: 400 Client Error: File already exists. See https://pypi.org/help/#file-name-reuse for url: https://upload.pypi.org/legacy/
```

This PR modifies the deploy step such that publish only occurs on the 3.6 build. and should fix the "errors" we're seeing on the 3 builds that can't deploy.

cc @sgillies 