### PR TITLE
Makes mercantile.children order explicit

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -363,6 +363,8 @@ def parent(*tile):
 def children(*tile):
     """Get the four children of a tile
 
+    The children are ordered: top-left, top-right, bottom-right, bottom-left.
+
     Parameters
     ----------
     tile : Tile or sequence of int

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -165,9 +165,32 @@ def test_parent():
 
 
 def test_children():
-    children = mercantile.children(243, 166, 9)
+    x, y, z = 243, 166, 9
+    children = mercantile.children(x, y, z)
     assert len(children) == 4
-    assert (486, 332, 10) in children
+
+    # Four sub-tiles (children) when zooming in
+    #
+    #    -------
+    #   | a | b |
+    #    ---|---
+    #   | d | c |
+    #    -------
+    #
+    # with:
+    #
+    #   a=(2x,     2y, z + 1)    b=(2x + 1,     2y, z + 1)
+    #
+    #   d=(2x, 2y + 1, z + 1)    c=(2x + 1, 2y + 1, z + 1)
+    #
+    # See: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Subtiles
+
+    a, b, c, d = children
+
+    assert a == mercantile.Tile(2 * x, 2 * y, z + 1)
+    assert b == mercantile.Tile(2 * x + 1, 2 * y, z + 1)
+    assert c == mercantile.Tile(2 * x + 1, 2 * y + 1, z + 1)
+    assert d == mercantile.Tile(2 * x, 2 * y + 1, z + 1)
 
 
 def test_bounding_tile():


### PR DESCRIPTION
I think we should document the order in which the `mercantile.children` function returns sub-tiles.

I just had a use-case where I needed this information and I had to look it up just to be sure. Let me know if the up/down left/right wording makes sense in the context of `mercantile` otherwise happy to re-word.