### PR TITLE
Handle converting empty quadkey to tile.

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -267,6 +267,8 @@ def quadkey_to_tile(qk):
     -------
     Tile
     """
+    if len(qk) == 0:
+        return Tile(0, 0, 0)
     xtile, ytile = 0, 0
     for i, digit in enumerate(reversed(qk)):
         mask = 1 << i

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -153,6 +153,12 @@ def test_quadkey_to_tile():
     assert mercantile.quadkey_to_tile(qk) == expected
 
 
+def test_empty_quadkey_to_tile():
+    qk = ""
+    expected = mercantile.Tile(0, 0, 0)
+    assert mercantile.quadkey_to_tile(qk) == expected
+
+
 def test_quadkey_failure():
     with pytest.raises(ValueError):
         mercantile.quadkey_to_tile('lolwut')


### PR DESCRIPTION
An empty quadkey specifies the zoom level 0 Tile.  Fixes #88.