### PR TITLE
Add Python 3.7 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - "pip install -r requirements.txt"
   - "pip install -e .[test]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - "pip install -r requirements.txt"
   - "pip install -e .[test]"
@@ -16,7 +17,7 @@ after_success:
 deploy:
   on:
     repo: mapbox/mercantile
-    python: 3.6
+    python: 3.7
     tags: true
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py27,py34,py35
+    py27,py34,py35,py36,py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Small PR that adds Python 3.7 to the Travis CI text matrix.  I ran the tests locally using Python 3.7.2 and they passed as expected prior to making this PR.  I noticed there's a tox.ini as well, so I added py36 and py37 to that in case anybody is using it.