### PR TITLE
Add a zoom option to parent and children, add simplify

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -4,14 +4,13 @@ from collections import namedtuple
 from collections import Sequence
 import math
 
-
 __version__ = '1.0.4'
 
 __all__ = [
     'Bbox', 'LngLat', 'LngLatBbox', 'Tile', 'bounding_tile', 'bounds',
     'children', 'feature', 'lnglat', 'parent', 'quadkey', 'quadkey_to_tile',
-    'tile', 'tiles', 'ul', 'xy_bounds']
-
+    'tile', 'tiles', 'ul', 'xy_bounds'
+]
 
 Tile = namedtuple('Tile', ['x', 'y', 'z'])
 """An XYZ web mercator tile
@@ -22,7 +21,6 @@ x, y, z : int
     x and y indexes of the tile and zoom level z.
 """
 
-
 LngLat = namedtuple('LngLat', ['lng', 'lat'])
 """A longitude and latitude pair
 
@@ -32,7 +30,6 @@ lng, lat : float
     Longitude and latitude in decimal degrees east or north.
 """
 
-
 LngLatBbox = namedtuple('LngLatBbox', ['west', 'south', 'east', 'north'])
 """A geographic bounding box
 
@@ -41,7 +38,6 @@ Attributes
 west, south, east, north : float
     Bounding values in decimal degrees.
 """
-
 
 Bbox = namedtuple('Bbox', ['left', 'bottom', 'right', 'top'])
 """A web mercator bounding box
@@ -85,7 +81,7 @@ def ul(*tile):
     if len(tile) == 1:
         tile = tile[0]
     xtile, ytile, zoom = tile
-    n = 2.0 ** zoom
+    n = 2.0**zoom
     lon_deg = xtile / n * 360.0 - 180.0
     lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * ytile / n)))
     lat_deg = math.degrees(lat_rad)
@@ -169,9 +165,8 @@ def lnglat(x, y, truncate=False):
     """
     R2D = 180 / math.pi
     A = 6378137.0
-    lng, lat = (
-        x * R2D / A,
-        ((math.pi * 0.5) - 2.0 * math.atan(math.exp(-y / A))) * R2D)
+    lng, lat = (x * R2D / A,
+                ((math.pi * 0.5) - 2.0 * math.atan(math.exp(-y / A))) * R2D)
     if truncate:
         lng, lat = truncate_lnglat(lng, lat)
     return LngLat(lng, lat)
@@ -216,12 +211,14 @@ def tile(lng, lat, zoom, truncate=False):
     if truncate:
         lng, lat = truncate_lnglat(lng, lat)
     lat = math.radians(lat)
-    n = 2.0 ** zoom
+    n = 2.0**zoom
     xtile = int(math.floor((lng + 180.0) / 360.0 * n))
 
     try:
-        ytile = int(math.floor((1.0 - math.log(
-            math.tan(lat) + (1.0 / math.cos(lat))) / math.pi) / 2.0 * n))
+        ytile = int(
+            math.floor(
+                (1.0 - math.log(math.tan(lat) +
+                                (1.0 / math.cos(lat))) / math.pi) / 2.0 * n))
     except ValueError:
         raise InvalidLatitudeError(
             "Y can not be computed for latitude {} radians".format(lat))
@@ -326,8 +323,8 @@ def tiles(west, south, east, north, zooms, truncate=False):
             llx = 0 if ll.x < 0 else ll.x
             ury = 0 if ur.y < 0 else ur.y
 
-            for i in range(llx, min(ur.x + 1, 2 ** z)):
-                for j in range(ury, min(ll.y + 1, 2 ** z)):
+            for i in range(llx, min(ur.x + 1, 2**z)):
+                for j in range(ury, min(ll.y + 1, 2**z)):
                     yield Tile(i, j, z)
 
 
@@ -354,16 +351,19 @@ def parent(*tile, zoom=None):
     if len(tile) == 1:
         tile = tile[0]
     if len(tile) == 2:
-        raise ValueError("Could not parse tile! Make sure that if you are calling this with zoom, you call this with zoom as a keyword argument.")
+        raise ValueError(
+            "Could not parse tile! Make sure that if you are calling this with zoom, you call this with zoom as a keyword argument."
+        )
 
     if zoom is not None and (tile[2] < zoom or zoom != int(zoom)):
-        raise ValueError("zoom must be an integer and less than the source tile!")
+        raise ValueError(
+            "zoom must be an integer and less than the source tile!")
 
-    x,y,z = tile
+    x, y, z = tile
     if x != int(x) or y != int(y) or z != int(z):
         raise ValueError("Cannot find the parent of a fractional tile!")
-    target_zoom = z-1 if zoom is None else zoom
-    
+    target_zoom = z - 1 if zoom is None else zoom
+
     # Algorithm heavily inspired by https://github.com/mapbox/tilebelt.
     return_tile = tile
     while return_tile[2] > target_zoom:
@@ -397,11 +397,14 @@ def children(*tile, zoom=None):
     if len(tile) == 1:
         tile = tile[0]
     if len(tile) == 2:
-        raise ValueError("Could not parse tile! Make sure that if you are calling this with zoom, you call this with zoom as a keyword argument.")
+        raise ValueError(
+            "Could not parse tile! Make sure that if you are calling this with zoom, you call this with zoom as a keyword argument."
+        )
     xtile, ytile, ztile = tile
 
     if zoom is not None and (ztile > zoom or zoom != int(zoom)):
-        raise ValueError("zoom must be an integer and greater than the source tile!")
+        raise ValueError(
+            "zoom must be an integer and greater than the source tile!")
 
     target_zoom = zoom if zoom is not None else ztile + 1
 
@@ -416,6 +419,7 @@ def children(*tile, zoom=None):
         ]
     return queue
 
+
 def simplify(*tiles):
     """Reduces the size of the tileset as much as possible by merging leaves into parents.
 
@@ -427,7 +431,13 @@ def simplify(*tiles):
     -------
     list
     """
+
     def merge(merge_set):
+        """Checks to see if there are 4 tiles in merge_set which can be merged.
+        If there are, this merges them.
+        This returns a list of tiles, as well as a boolean indicating if any were merged.
+        By repeatedly applying merge, a tileset can be simplified.
+        """
         upwards_merge = {}
         for tile in merge_set:
             tile_parent = parent(tile)
@@ -444,22 +454,22 @@ def simplify(*tiles):
                 current_tileset += list(children)
         return current_tileset, changed
 
+    # Check to see if a tile and its parent both already exist.
+    # If so, discard the child (it's covered in the parent)
     root_set = set()
     for tile in tiles:
-        x,y,z = tile
-        supers = [parent(tile, zoom=i) for i in range(z+1)]
+        x, y, z = tile
+        supers = [parent(tile, zoom=i) for i in range(z + 1)]
         for supertile in supers:
             if supertile in root_set:
                 continue
         root_set |= {tile}
+
+    # Repeatedly run merge until no further simplification is possible.
     is_merging = True
     while is_merging:
         root_set, is_merging = merge(root_set)
     return root_set
-
-    
-
-
 
 
 def rshift(val, n):
@@ -509,15 +519,18 @@ def _getBboxZoom(*bbox):
     MAX_ZOOM = 28
     for z in range(0, MAX_ZOOM):
         mask = 1 << (32 - (z + 1))
-        if ((bbox[0] & mask) != (bbox[2] & mask) or
-                (bbox[1] & mask) != (bbox[3] & mask)):
+        if ((bbox[0] & mask) != (bbox[2] & mask) or (bbox[1] & mask) !=
+            (bbox[3] & mask)):
             return z
     return MAX_ZOOM
 
 
-def feature(
-        tile, fid=None, props=None, projected='geographic', buffer=None,
-        precision=None):
+def feature(tile,
+            fid=None,
+            props=None,
+            projected='geographic',
+            buffer=None,
+            precision=None):
     """Get the GeoJSON feature corresponding to a tile
 
     Parameters
@@ -551,26 +564,30 @@ def feature(
         east += buffer
         north += buffer
     if precision and precision >= 0:
-        west, south, east, north = (
-            round(v, precision) for v in (west, south, east, north))
+        west, south, east, north = (round(v, precision)
+                                    for v in (west, south, east, north))
     bbox = [
-        min(west, east), min(south, north),
-        max(west, east), max(south, north)]
+        min(west, east),
+        min(south, north),
+        max(west, east),
+        max(south, north)
+    ]
     geom = {
-        'type': 'Polygon',
-        'coordinates': [[
-            [west, south],
-            [west, north],
-            [east, north],
-            [east, south],
-            [west, south]]]}
+        'type':
+        'Polygon',
+        'coordinates': [[[west, south], [west, north], [east, north],
+                         [east, south], [west, south]]]
+    }
     xyz = str(tile)
     feat = {
         'type': 'Feature',
         'bbox': bbox,
         'id': xyz,
         'geometry': geom,
-        'properties': {'title': 'XYZ tile %s' % xyz}}
+        'properties': {
+            'title': 'XYZ tile %s' % xyz
+        }
+    }
     if props:
         feat['properties'].update(props)
     if fid:

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -9,8 +9,7 @@ __version__ = '1.0.4'
 __all__ = [
     'Bbox', 'LngLat', 'LngLatBbox', 'Tile', 'bounding_tile', 'bounds',
     'children', 'feature', 'lnglat', 'parent', 'quadkey', 'quadkey_to_tile',
-    'tile', 'tiles', 'ul', 'xy_bounds'
-]
+    'tile', 'tiles', 'ul', 'xy_bounds']
 
 Tile = namedtuple('Tile', ['x', 'y', 'z'])
 """An XYZ web mercator tile
@@ -81,7 +80,7 @@ def ul(*tile):
     if len(tile) == 1:
         tile = tile[0]
     xtile, ytile, zoom = tile
-    n = 2.0**zoom
+    n = 2.0 ** zoom
     lon_deg = xtile / n * 360.0 - 180.0
     lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * ytile / n)))
     lat_deg = math.degrees(lat_rad)
@@ -165,8 +164,9 @@ def lnglat(x, y, truncate=False):
     """
     R2D = 180 / math.pi
     A = 6378137.0
-    lng, lat = (x * R2D / A,
-                ((math.pi * 0.5) - 2.0 * math.atan(math.exp(-y / A))) * R2D)
+    lng, lat = (
+        x * R2D / A,
+        ((math.pi * 0.5) - 2.0 * math.atan(math.exp(-y / A))) * R2D)
     if truncate:
         lng, lat = truncate_lnglat(lng, lat)
     return LngLat(lng, lat)
@@ -211,13 +211,11 @@ def tile(lng, lat, zoom, truncate=False):
     if truncate:
         lng, lat = truncate_lnglat(lng, lat)
     lat = math.radians(lat)
-    n = 2.0**zoom
+    n = 2.0 ** zoom
     xtile = int(math.floor((lng + 180.0) / 360.0 * n))
 
     try:
-        ytile = int(
-            math.floor(
-                (1.0 - math.log(math.tan(lat) +
+        ytile = int(math.floor((1.0 - math.log(math.tan(lat) +
                                 (1.0 / math.cos(lat))) / math.pi) / 2.0 * n))
     except ValueError:
         raise InvalidLatitudeError(
@@ -323,8 +321,8 @@ def tiles(west, south, east, north, zooms, truncate=False):
             llx = 0 if ll.x < 0 else ll.x
             ury = 0 if ur.y < 0 else ur.y
 
-            for i in range(llx, min(ur.x + 1, 2**z)):
-                for j in range(ury, min(ll.y + 1, 2**z)):
+            for i in range(llx, min(ur.x + 1, 2 ** z)):
+                for j in range(ury, min(ll.y + 1, 2 ** z)):
                     yield Tile(i, j, z)
 
 
@@ -340,7 +338,7 @@ def parent(*tile, **kwargs):
         May be be either an instance of Tile or 3 ints, X, Y, Z.
     zoom : int, optional
         Returns the parent at zoom *zoom*.
-        This defaults to one lower than the tile (the immediate parent).
+        This defaults to one lower than the tile (the immediate parent). 
 
     Returns
     -------
@@ -521,17 +519,13 @@ def _getBboxZoom(*bbox):
     MAX_ZOOM = 28
     for z in range(0, MAX_ZOOM):
         mask = 1 << (32 - (z + 1))
-        if ((bbox[0] & mask) != (bbox[2] & mask) or (bbox[1] & mask) !=
-            (bbox[3] & mask)):
+        if ((bbox[0] & mask) != (bbox[2] & mask) or 
+                (bbox[1] & mask) != (bbox[3] & mask)):
             return z
     return MAX_ZOOM
 
 
-def feature(tile,
-            fid=None,
-            props=None,
-            projected='geographic',
-            buffer=None,
+def feature(tile, fid=None, props=None, projected='geographic', buffer=None,
             precision=None):
     """Get the GeoJSON feature corresponding to a tile
 
@@ -566,29 +560,28 @@ def feature(tile,
         east += buffer
         north += buffer
     if precision and precision >= 0:
-        west, south, east, north = (round(v, precision)
-                                    for v in (west, south, east, north))
+        west, south, east, north = (
+            round(v, precision) for v in (west, south, east, north))
     bbox = [
-        min(west, east),
-        min(south, north),
-        max(west, east),
-        max(south, north)
+        min(west, east), min(south, north),
+        max(west, east), max(south, north)
     ]
     geom = {
         'type':
         'Polygon',
-        'coordinates': [[[west, south], [west, north], [east, north],
-                         [east, south], [west, south]]]
-    }
+        'coordinates': [[
+            [west, south], 
+            [west, north], 
+            [east, north],
+            [east, south],
+            [west, south]]]}
     xyz = str(tile)
     feat = {
         'type': 'Feature',
         'bbox': bbox,
         'id': xyz,
         'geometry': geom,
-        'properties': {
-            'title': 'XYZ tile %s' % xyz
-        }
+        'properties': {'title': 'XYZ tile %s' % xyz}
     }
     if props:
         feat['properties'].update(props)

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -408,16 +408,16 @@ def children(*tile, **kwargs):
 
     target_zoom = zoom if zoom is not None else ztile + 1
 
-    queue = [tile]
-    while queue[0][2] < target_zoom:
-        xtile, ytile, ztile = queue.pop(0)
-        queue += [
+    tiles = [tile]
+    while tiles[0][2] < target_zoom:
+        xtile, ytile, ztile = tiles.pop(0)
+        tiles += [
             Tile(xtile * 2, ytile * 2, ztile + 1),
             Tile(xtile * 2 + 1, ytile * 2, ztile + 1),
             Tile(xtile * 2 + 1, ytile * 2 + 1, ztile + 1),
             Tile(xtile * 2, ytile * 2 + 1, ztile + 1)
         ]
-    return queue
+    return tiles
 
 
 def simplify(*tiles):

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -4,12 +4,14 @@ from collections import namedtuple
 from collections import Sequence
 import math
 
+
 __version__ = '1.0.4'
 
 __all__ = [
     'Bbox', 'LngLat', 'LngLatBbox', 'Tile', 'bounding_tile', 'bounds',
     'children', 'feature', 'lnglat', 'parent', 'quadkey', 'quadkey_to_tile',
     'tile', 'tiles', 'ul', 'xy_bounds']
+
 
 Tile = namedtuple('Tile', ['x', 'y', 'z'])
 """An XYZ web mercator tile
@@ -20,6 +22,7 @@ x, y, z : int
     x and y indexes of the tile and zoom level z.
 """
 
+
 LngLat = namedtuple('LngLat', ['lng', 'lat'])
 """A longitude and latitude pair
 
@@ -29,6 +32,7 @@ lng, lat : float
     Longitude and latitude in decimal degrees east or north.
 """
 
+
 LngLatBbox = namedtuple('LngLatBbox', ['west', 'south', 'east', 'north'])
 """A geographic bounding box
 
@@ -37,6 +41,7 @@ Attributes
 west, south, east, north : float
     Bounding values in decimal degrees.
 """
+
 
 Bbox = namedtuple('Bbox', ['left', 'bottom', 'right', 'top'])
 """A web mercator bounding box
@@ -215,8 +220,8 @@ def tile(lng, lat, zoom, truncate=False):
     xtile = int(math.floor((lng + 180.0) / 360.0 * n))
 
     try:
-        ytile = int(math.floor((1.0 - math.log(math.tan(lat) +
-                                (1.0 / math.cos(lat))) / math.pi) / 2.0 * n))
+        ytile = int(math.floor((1.0 - math.log(
+            math.tan(lat) + (1.0 / math.cos(lat))) / math.pi) / 2.0 * n))
     except ValueError:
         raise InvalidLatitudeError(
             "Y can not be computed for latitude {} radians".format(lat))
@@ -519,14 +524,15 @@ def _getBboxZoom(*bbox):
     MAX_ZOOM = 28
     for z in range(0, MAX_ZOOM):
         mask = 1 << (32 - (z + 1))
-        if ((bbox[0] & mask) != (bbox[2] & mask) or 
+        if ((bbox[0] & mask) != (bbox[2] & mask) or
                 (bbox[1] & mask) != (bbox[3] & mask)):
             return z
     return MAX_ZOOM
 
 
-def feature(tile, fid=None, props=None, projected='geographic', buffer=None,
-            precision=None):
+def feature(
+        tile, fid=None, props=None, projected='geographic', buffer=None,
+        precision=None):
     """Get the GeoJSON feature corresponding to a tile
 
     Parameters
@@ -564,11 +570,9 @@ def feature(tile, fid=None, props=None, projected='geographic', buffer=None,
             round(v, precision) for v in (west, south, east, north))
     bbox = [
         min(west, east), min(south, north),
-        max(west, east), max(south, north)
-    ]
+        max(west, east), max(south, north)]
     geom = {
-        'type':
-        'Polygon',
+        'type': 'Polygon',
         'coordinates': [[
             [west, south], 
             [west, north], 
@@ -581,8 +585,7 @@ def feature(tile, fid=None, props=None, projected='geographic', buffer=None,
         'bbox': bbox,
         'id': xyz,
         'geometry': geom,
-        'properties': {'title': 'XYZ tile %s' % xyz}
-    }
+        'properties': {'title': 'XYZ tile %s' % xyz}}
     if props:
         feat['properties'].update(props)
     if fid:

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -328,7 +328,7 @@ def tiles(west, south, east, north, zooms, truncate=False):
                     yield Tile(i, j, z)
 
 
-def parent(*tile, zoom=None):
+def parent(*tile, **kwargs):
     """Get the parent of a tile
 
     The parent is the tile of one zoom level lower that contains the
@@ -346,7 +346,7 @@ def parent(*tile, zoom=None):
     -------
     Tile
     """
-    # TODO CLEAN ME UP
+    zoom = kwargs.get("zoom", None)
 
     if len(tile) == 1:
         tile = tile[0]
@@ -379,7 +379,7 @@ def parent(*tile, zoom=None):
     return return_tile
 
 
-def children(*tile, zoom=None):
+def children(*tile, **kwargs):
     """Get the children of a tile
 
     Parameters
@@ -394,6 +394,8 @@ def children(*tile, zoom=None):
     -------
     list
     """
+    zoom = kwargs.get("zoom", None)
+
     if len(tile) == 1:
         tile = tile[0]
     if len(tile) == 2:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -208,45 +208,48 @@ def test_children_multi():
     for target in targets:
         assert target in children
 
-def test_children_parent_bad_tile_args():
-    try:
-        mercantile.children((243, 166, 9), 10)
-    except ValueError as e:
-        assert "Could not parse tile!" in str(e)
 
-    try:
+def test_children_bad_tile_args():
+    with pytest.raises(ValueError) as e:
+        mercantile.children((243, 166, 9), 10)
+    assert "Could not parse tile!" in str(e)
+
+
+def test_parent_bad_tile_args():
+    with pytest.raises(ValueError) as e:
         mercantile.parent((243, 166, 9), 1)
-    except ValueError as e:
-        assert "Could not parse tile!" in str(e)
+    assert "Could not parse tile!" in str(e)
+
 
 def test_child_fractional_zoom():
-    try:
+    with pytest.raises(ValueError) as e:
         mercantile.children((243, 166, 9), zoom=10.2)
-    except ValueError as e:
-        assert "zoom must be an integer and greater than the source tile!" in str(e)
+    assert "zoom must be an integer and greater than the source tile!" in str(e)
     
+
 def test_child_bad_tile_zoom():
-    try:
+    with pytest.raises(ValueError) as e:
         mercantile.children((243, 166, 9), zoom=8)
-    except ValueError as e:
-        assert "zoom must be an integer and greater than the source tile!" in str(e)
+    assert "zoom must be an integer and greater than the source tile!" in str(e)
 
 
 def test_parent_fractional_tile():
-    try:
+    with pytest.raises(ValueError) as e:
         mercantile.parent((243.3, 166.2, 9), zoom=1)
-    except ValueError as e:
-        assert "Cannot find the parent of a fractional tile!" in str(e)
-    try:
+    assert "Cannot find the parent of a fractional tile!" in str(e)
+
+
+def test_parent_fractional_zoom():
+    with pytest.raises(ValueError) as e:
         mercantile.parent((243, 166, 9), zoom=1.2)
-    except ValueError as e:
-        assert "zoom must be an integer and less than the source tile!" in str(e)
+    assert "zoom must be an integer and less than the source tile!" in str(e)
+
 
 def test_parent_bad_tile_zoom():
-    try:
+    with pytest.raises(ValueError) as e:
         mercantile.parent((243.3, 166.2, 9), zoom=10)
-    except ValueError as e:
-        assert "zoom must be an integer and less than the source tile!" in str(e)
+    assert "zoom must be an integer and less than the source tile!" in str(e)
+
 
 def test_simplify():
     children = mercantile.children(243, 166, 9, zoom=12)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -187,25 +187,66 @@ def test_children():
 def test_children_multi():
     children = mercantile.children(243, 166, 9, zoom=11)
     assert len(children) == 16
-    targets = [(972, 664, 11),
- (973, 664, 11),
- (973, 665, 11),
- (972, 665, 11),
- (974, 664, 11),
- (975, 664, 11),
- (975, 665, 11),
- (974, 665, 11),
- (974, 666, 11),
- (975, 666, 11),
- (975, 667, 11),
- (974, 667, 11),
- (972, 666, 11),
- (973, 666, 11),
- (973, 667, 11),
- (972, 667, 11)]
+    targets = [
+        (972, 664, 11),
+        (973, 664, 11),
+        (973, 665, 11),
+        (972, 665, 11),
+        (974, 664, 11),
+        (975, 664, 11),
+        (975, 665, 11),
+        (974, 665, 11),
+        (974, 666, 11),
+        (975, 666, 11),
+        (975, 667, 11),
+        (974, 667, 11),
+        (972, 666, 11),
+        (973, 666, 11),
+        (973, 667, 11),
+        (972, 667, 11),
+    ]
     for target in targets:
         assert target in children
 
+def test_children_parent_bad_tile_args():
+    try:
+        mercantile.children((243, 166, 9), 10)
+    except ValueError as e:
+        assert "Could not parse tile!" in str(e)
+
+    try:
+        mercantile.parent((243, 166, 9), 1)
+    except ValueError as e:
+        assert "Could not parse tile!" in str(e)
+
+def test_child_fractional_zoom():
+    try:
+        mercantile.children((243, 166, 9), zoom=10.2)
+    except ValueError as e:
+        assert "zoom must be an integer and greater than the source tile!" in str(e)
+    
+def test_child_bad_tile_zoom():
+    try:
+        mercantile.children((243, 166, 9), zoom=8)
+    except ValueError as e:
+        assert "zoom must be an integer and greater than the source tile!" in str(e)
+
+
+def test_parent_fractional_tile():
+    try:
+        mercantile.parent((243.3, 166.2, 9), zoom=1)
+    except ValueError as e:
+        assert "Cannot find the parent of a fractional tile!" in str(e)
+    try:
+        mercantile.parent((243, 166, 9), zoom=1.2)
+    except ValueError as e:
+        assert "zoom must be an integer and less than the source tile!" in str(e)
+
+def test_parent_bad_tile_zoom():
+    try:
+        mercantile.parent((243.3, 166.2, 9), zoom=10)
+    except ValueError as e:
+        assert "zoom must be an integer and less than the source tile!" in str(e)
 
 def test_simplify():
     children = mercantile.children(243, 166, 9, zoom=12)
@@ -213,15 +254,17 @@ def test_simplify():
     children = children[:-3]
     children.append(children[0])
     simplified = mercantile.simplify(*children)
-    targets = [(487, 332, 10),
-                (486, 332, 10),
-                (487, 333, 10), 
-                (973, 667, 11),
-                (973, 666, 11),
-                (972, 666, 11),
-                (1944, 1334, 12)]
+    targets = [
+        (487, 332, 10),
+        (486, 332, 10),
+        (487, 333, 10),
+        (973, 667, 11),
+        (973, 666, 11),
+        (972, 666, 11),
+        (1944, 1334, 12),
+    ]
     for target in targets:
-            assert target in simplified
+        assert target in simplified
 
 
 def test_bounding_tile():

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -3,10 +3,9 @@ import pytest
 import mercantile
 
 
-@pytest.mark.parametrize('args', [
-    (486, 332, 10),
-    [(486, 332, 10)],
-    [mercantile.Tile(486, 332, 10)]])
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+)
 def test_ul(args):
     expected = (-9.140625, 53.33087298301705)
     lnglat = mercantile.ul(*args)
@@ -16,10 +15,9 @@ def test_ul(args):
     assert lnglat[1] == lnglat.lat
 
 
-@pytest.mark.parametrize('args', [
-    (486, 332, 10),
-    [(486, 332, 10)],
-    [mercantile.Tile(486, 332, 10)]])
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+)
 def test_bbox(args):
     expected = (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)
     bbox = mercantile.bounds(*args)
@@ -50,12 +48,12 @@ def test_xy_null_island():
 
 def test_xy_south_pole():
     """Return -inf for y at South Pole"""
-    assert mercantile.xy(0.0, -90) == (0.0, float('-inf'))
+    assert mercantile.xy(0.0, -90) == (0.0, float("-inf"))
 
 
 def test_xy_north_pole():
     """Return inf for y at North Pole"""
-    assert mercantile.xy(0.0, 90) == (0.0, float('inf'))
+    assert mercantile.xy(0.0, 90) == (0.0, float("inf"))
 
 
 def test_xy_truncate():
@@ -80,13 +78,16 @@ def test_lnglat_xy_roundtrip():
         assert round(a - b, 4) == 0
 
 
-@pytest.mark.parametrize('args', [
-    (486, 332, 10),
-    [(486, 332, 10)],
-    [mercantile.Tile(486, 332, 10)]])
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+)
 def test_xy_bounds(args):
-    expected = (-1017529.7205322663, 7005300.768279833,
-                -978393.962050256, 7044436.526761846)
+    expected = (
+        -1017529.7205322663,
+        7005300.768279833,
+        -978393.962050256,
+        7044436.526761846,
+    )
     bounds = mercantile.xy_bounds(*args)
 
     for a, b in zip(expected, bounds):
@@ -102,29 +103,36 @@ def test_tile():
 
 def test_tile_truncate():
     """Input is truncated"""
-    assert mercantile.tile(-181.0, 0.0, 9, truncate=True) == mercantile.tile(-180.0, 0.0, 9)
+    assert mercantile.tile(-181.0, 0.0, 9, truncate=True) == mercantile.tile(
+        -180.0, 0.0, 9
+    )
 
 
 def test_tiles():
     bounds = (-105, 39.99, -104.99, 40)
     tiles = list(mercantile.tiles(*bounds, zooms=[14]))
-    expect = [mercantile.Tile(x=3413, y=6202, z=14),
-              mercantile.Tile(x=3413, y=6203, z=14)]
+    expect = [
+        mercantile.Tile(x=3413, y=6202, z=14),
+        mercantile.Tile(x=3413, y=6203, z=14),
+    ]
     assert sorted(tiles) == sorted(expect)
 
 
 def test_tiles_single_zoom():
     bounds = (-105, 39.99, -104.99, 40)
     tiles = list(mercantile.tiles(*bounds, zooms=14))
-    expect = [mercantile.Tile(x=3413, y=6202, z=14),
-              mercantile.Tile(x=3413, y=6203, z=14)]
+    expect = [
+        mercantile.Tile(x=3413, y=6202, z=14),
+        mercantile.Tile(x=3413, y=6203, z=14),
+    ]
     assert sorted(tiles) == sorted(expect)
 
 
 def test_tiles_truncate():
     """Input is truncated"""
-    assert list(mercantile.tiles(-181.0, 0.0, -170.0, 10.0, zooms=[2], truncate=True)) \
-        == list(mercantile.tiles(-180.0, 0.0, -170.0, 10.0, zooms=[2]))
+    assert list(
+        mercantile.tiles(-181.0, 0.0, -170.0, 10.0, zooms=[2], truncate=True)
+    ) == list(mercantile.tiles(-180.0, 0.0, -170.0, 10.0, zooms=[2]))
 
 
 def test_tiles_antimerdian_crossing_bbox():
@@ -155,13 +163,14 @@ def test_quadkey_to_tile():
 
 def test_quadkey_failure():
     with pytest.raises(ValueError):
-        mercantile.quadkey_to_tile('lolwut')
+        mercantile.quadkey_to_tile("lolwut")
 
 
 def test_parent():
     parent = mercantile.parent(486, 332, 10)
     assert parent == (243, 166, 9)
     assert parent.z == 9
+
 
 def test_parent_multi():
     parent = mercantile.parent(486, 332, 10, zoom=8)
@@ -174,10 +183,29 @@ def test_children():
     assert len(children) == 4
     assert (486, 332, 10) in children
 
+
 def test_children_multi():
     children = mercantile.children(243, 166, 9, zoom=11)
     assert len(children) == 16
-    assert (972, 664, 11) in children
+    targets = [(972, 664, 11),
+ (973, 664, 11),
+ (973, 665, 11),
+ (972, 665, 11),
+ (974, 664, 11),
+ (975, 664, 11),
+ (975, 665, 11),
+ (974, 665, 11),
+ (974, 666, 11),
+ (975, 666, 11),
+ (975, 667, 11),
+ (974, 667, 11),
+ (972, 666, 11),
+ (973, 666, 11),
+ (973, 667, 11),
+ (972, 667, 11)]
+    for target in targets:
+        assert target in children
+
 
 def test_simplify():
     children = mercantile.children(243, 166, 9, zoom=12)
@@ -185,7 +213,15 @@ def test_simplify():
     children = children[:-3]
     children.append(children[0])
     simplified = mercantile.simplify(*children)
-    assert len(simplified) == 7
+    targets = [(487, 332, 10),
+                (486, 332, 10),
+                (487, 333, 10), 
+                (973, 667, 11),
+                (973, 666, 11),
+                (972, 666, 11),
+                (1944, 1334, 12)]
+    for target in targets:
+            assert target in simplified
 
 
 def test_bounding_tile():
@@ -196,10 +232,8 @@ def test_bounding_tile():
 
 def test_overflow_bounding_tile():
     assert mercantile.bounding_tile(
-        -179.99999999999997,
-        -90.00000000000003,
-        180.00000000000014,
-        -63.27066048950458) == (0, 0, 0)
+        -179.99999999999997, -90.00000000000003, 180.00000000000014, -63.27066048950458
+    ) == (0, 0, 0)
 
 
 def test_bounding_tile_pt():
@@ -209,8 +243,9 @@ def test_bounding_tile_pt():
 
 def test_bounding_tile_truncate():
     """Input is truncated"""
-    assert mercantile.bounding_tile(-181.0, 1.0, truncate=True) \
-        == mercantile.bounding_tile(-180.0, 1.0)
+    assert mercantile.bounding_tile(
+        -181.0, 1.0, truncate=True
+    ) == mercantile.bounding_tile(-180.0, 1.0)
 
 
 def test_truncate_lng_under():


### PR DESCRIPTION
I have often found myself writing code to get all children at a specified zoom level (e.g. all zoom-15 children of a zoom-9 tile, or the zoom-9 parent of a zoom-15 tile).

I think this is a pretty frequent use case, so I've added a keyword argument for zoom to `parent(*tile, zoom=None)` and `children(*tile, zoom=None)`, along with a few tests.  The change should be backwards-compatible.

I've also added a function `simplify(*tiles)` which accepts a list of tiles and attempts to merge children into parents.

Please let me know any feedback you have.