### PR TITLE
Exclude bottom and right edge of tiles when computing bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ venv2/
 
 .DS_Store
 .pytest_cache
+package-lock.json
+node_modules
+.hypothesis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
-sudo: false
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "3.8"
 install:
   - "pip install -r requirements.txt"
+  - "pip install pytest-cov~=2.8 pytest~=5.0"
   - "pip install -e .[test]"
 script:
   - "python -m pytest --cov mercantile --cov-report term-missing"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.8"
 install:
   - "pip install -r requirements.txt"
-  - "pip install pytest-cov~=2.8 pytest~=5.0"
+  - "pip install pytest-cov~=2.8 pytest~=5.3.0"
   - "pip install -e .[test]"
 script:
   - "python -m pytest --cov mercantile --cov-report term-missing"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 Next
 ----
 
+- The implementation of xy_bounds has been simplified and improved.
 - The geographic bounds of a tile have been made slightly smaller by
   subtracting epsilon from the right limit and adding epsilon to the bottom
   limit. The bounding tile of the bounds of a tile is now that same tile (#100).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Next
+----
+
+- The geographic bounds of a tile have been made slightly smaller by
+  subtracting epsilon from the right limit and adding epsilon to the bottom
+  limit. The bounding tile of the bounds of a tile is now that same tile (#100).
+
 1.1.2 (2019-08-05)
 ------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,10 +4,7 @@ Changes
 1.1.3 (TBD)
 -----------
 
-- The implementation of xy_bounds has been simplified and improved.
-- The geographic bounds of a tile have been made slightly smaller by
-  subtracting epsilon from the right limit and adding epsilon to the bottom
-  limit. The bounding tile of the bounds of a tile is now that same tile (#100).
+- The bounding tile of the bounds of a tile is now that same tile (#100).
 
 1.1.2 (2019-08-05)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,8 @@
 Changes
 =======
 
-Next
-----
+1.1.3 (TBD)
+-----------
 
 - The implementation of xy_bounds has been simplified and improved.
 - The geographic bounds of a tile have been made slightly smaller by

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -36,7 +36,8 @@ __all__ = [
 R2D = 180 / math.pi
 RE = 6378137.0
 CE = 2 * math.pi * RE
-EPSILON = 1e-10
+LL_EPSILON = 1e-13
+XY_EPSILON = 1e-8
 
 
 Tile = namedtuple("Tile", ["x", "y", "z"])
@@ -183,7 +184,7 @@ def bounds(*tile):
     xtile, ytile, zoom = tile
     a = ul(xtile, ytile, zoom)
     b = ul(xtile + 1, ytile + 1, zoom)
-    return LngLatBbox(a[0], b[1] + EPSILON, b[0] - EPSILON, a[1])
+    return LngLatBbox(a[0], b[1] + LL_EPSILON, b[0] - LL_EPSILON, a[1])
 
 
 def truncate_lnglat(lng, lat):
@@ -278,10 +279,10 @@ def xy_bounds(*tile):
     tile_size = CE / (2 ** zoom)
 
     left = xtile * tile_size - CE / 2
-    right = left + tile_size - EPSILON
+    right = left + tile_size - XY_EPSILON
 
     top = CE / 2 - ytile * tile_size
-    bottom = top - tile_size + EPSILON
+    bottom = top - tile_size + XY_EPSILON
 
     return Bbox(left, bottom, right, top)
 

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -11,7 +11,7 @@ else:
     from collections.abc import Sequence
 
 
-__version__ = "1.1.2"
+__version__ = "1.1.3dev"
 
 __all__ = [
     "Bbox",

--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -306,6 +306,7 @@ def _xy(lng, lat, truncate=False):
         y = y + EPSILON
         return x, y
 
+
 def tile(lng, lat, zoom, truncate=False):
     """Get the tile containing a longitude and latitude
 
@@ -446,7 +447,9 @@ def tiles(west, south, east, north, zooms, truncate=False):
             ulx = 0 if ulx < 0 else ulx
             uly = 0 if uly < 0 else uly
 
-            minx, miny, maxx, maxy = map(lambda x: int(math.floor(x)), [ulx, uly, lrx, lry])
+            minx, miny, maxx, maxy = map(
+                lambda x: int(math.floor(x)), [ulx, uly, lrx, lry]
+            )
 
             for i in range(minx, min(maxx + 1, 2 ** z)):
                 for j in range(miny, min(maxy + 1, 2 ** z)):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=["click>=3.0"],
     extras_require={
         "dev": ["check-manifest"],
-        "test": ["coveralls", "pytest-cov", "pydocstyle"],
+        "test": ["coveralls", "hypothesis", "pytest-cov", "pydocstyle"],
     },
     entry_points="""
       [console_scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests of the mercantile CLI"""
 
 from click.testing import CliRunner
+import pytest
 
 from mercantile.scripts import cli
 
@@ -318,7 +319,8 @@ def test_cli_tiles_point_geojson():
 def test_cli_quadkey_failure():
     """Abort when an invalid quadkey is passed"""
     runner = CliRunner()
-    result = runner.invoke(cli, ["quadkey", "lolwut"])
+    with pytest.warns(DeprecationWarning):
+        result = runner.invoke(cli, ["quadkey", "lolwut"])
     assert result.exit_code == 2
     assert "lolwut" in result.output
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -378,3 +378,19 @@ def test_arg_parse_error(args):
     """Helper function raises exception as expected"""
     with pytest.raises(mercantile.TileArgParsingError):
         mercantile._parse_tile_arg(*args)
+
+
+@pytest.mark.parametrize(
+    "t",
+    [
+        mercantile.Tile(x=3413, y=6202, z=14),
+        mercantile.Tile(486, 332, 10),
+        mercantile.Tile(x=69327, y=45014, z=17),
+    ],
+)
+def test_bounding_tile_roundtrip(t):
+    """bounding_tile(bounds(tile)) gives the tile"""
+    val = mercantile.bounding_tile(*mercantile.bounds(t))
+    assert val.x == t.x
+    assert val.y == t.y
+    assert val.z == t.z

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -154,7 +154,12 @@ def test_global_tiles_clamped():
 
 
 @pytest.mark.parametrize(
-    "t", [mercantile.Tile(x=3413, y=6202, z=14), mercantile.Tile(486, 332, 10), mercantile.Tile(10, 10, 10)]
+    "t",
+    [
+        mercantile.Tile(x=3413, y=6202, z=14),
+        mercantile.Tile(486, 332, 10),
+        mercantile.Tile(10, 10, 10),
+    ],
 )
 def test_tiles_roundtrip(t):
     """tiles(bounds(tile)) gives the tile"""


### PR DESCRIPTION
Resolves #100

In essence, points along the bottom and right edge of a tile are not "in" the tile. Points along the left and top edges are. This makes round tripping between bounding_tile or tile and bounds predictable.

Would appreciate your reviews and comments anyone. Especially @dnomadb and @brendan-ward .