### PR TITLE
Adds tile pre-conditions and validation, closes #122 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - "pip install -r requirements.txt"
   - "pip install pytest-cov~=2.8 pytest~=5.3.0"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+1.1.7 (2021-03-01)
+------------------
+
+- Add tile pre-conditions and input validation (#122)
+
 1.1.6 (2020-08-24)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# To develop in a reproducible dev environment
+#
+# 1. build the docker image
+#
+#   docker build -t mapbox/mercantile .
+#
+# 2. mount the source into the container and run tests
+#
+#   docker run --rm -v $PWD:/usr/src/app mapbox/mercantile
+
+
+FROM python:3.9-slim
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install pytest-cov~=2.8 pytest~=5.3.0
+
+COPY . .
+
+RUN pip install -e .[test]
+
+CMD ["python", "-m", "pytest"]

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -7,6 +7,32 @@ import pytest
 import mercantile
 
 
+def test_invalid_tile():
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(0, 0, -1)
+    assert "must be a positive int" in str(e.value)
+
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(0, 0, 0.5)
+    assert "must be a positive int" in str(e.value)
+
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(0.5, 0, 0)
+    assert "must be an int" in str(e.value)
+
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(0, 0.5, 0)
+    assert "must be an int" in str(e.value)
+
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(1, 1, 0)
+    assert "must be an integer in" in str(e.value)
+
+    with pytest.raises(mercantile.TileArgParsingError) as e:
+        mercantile._parse_tile_arg(0, (2 ** 10 - 1) + 1, 10)
+    assert "must be an integer in" in str(e.value)
+
+
 @pytest.mark.parametrize(
     "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
 )
@@ -224,6 +250,16 @@ def test_parent_multi():
     assert parent.z == 8
 
 
+def test_parent_same_zoom():
+    with pytest.raises(mercantile.InvalidZoomError):
+        parent = mercantile.parent(486, 332, 10, zoom=10)
+
+
+def test_parent_root_tile():
+    with pytest.raises(mercantile.ParentTileError):
+        parent = mercantile.parent(0, 0, 0)
+
+
 def test_children():
     x, y, z = 243, 166, 9
     children = mercantile.children(x, y, z)
@@ -291,9 +327,9 @@ def test_child_bad_tile_zoom():
 
 
 def test_parent_fractional_tile():
-    with pytest.raises(mercantile.ParentTileError) as e:
+    with pytest.raises(mercantile.TileArgParsingError) as e:
         mercantile.parent((243.3, 166.2, 9), zoom=1)
-    assert "the parent of a non-integer tile is undefined" in str(e.value)
+    assert "must be an int" in str(e.value)
 
 
 def test_parent_fractional_zoom():
@@ -303,9 +339,9 @@ def test_parent_fractional_zoom():
 
 
 def test_parent_bad_tile_zoom():
-    with pytest.raises(mercantile.InvalidZoomError) as e:
+    with pytest.raises(mercantile.TileArgParsingError) as e:
         mercantile.parent((243.3, 166.2, 9), zoom=10)
-    assert "zoom must be an integer and less than" in str(e.value)
+    assert "must be an int" in str(e.value)
 
 
 def test_simplify():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py27,py34,py35,py36,py37
+    py27,py34,py35,py36,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
For #122.

I've added pre-conditions and validation to the tile parsing logic.

This uncovered two existing problems in mercantile
- one problem in simplify I could fix, and
- one problem in the bounds <-> bounding_tile roundtrip I'm unsure how to fix properly (see inline comments)


Note: I've cherry-picked some commits from #123 in here to develop locally.