### PR TITLE
Raise when nan bounds are passed to tiles

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -518,6 +518,9 @@ def tiles(west, south, east, north, zooms, truncate=False):
     function yields exactly one tile when given the bounds of that same tile.
 
     """
+    if any(math.isnan(coord) for coord in (west, south, east, north)):
+        raise MercantileError("All coordinates must be finite.")
+
     if truncate:
         west, south = truncate_lnglat(west, south)
         east, north = truncate_lnglat(east, north)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 from hypothesis import example, given
@@ -177,6 +178,10 @@ def test_tiles_roundtrip_children():
     res = list(mercantile.tiles(*mercantile.bounds(t), zooms=[15]))
     assert len(res) == 4
 
+def test_tiles_nan_bounds():
+    bounds = (-105, math.nan, -104.99, 40)
+    with pytest.raises(mercantile.MercantileError):
+        list(mercantile.tiles(*bounds, zooms=[14]))
 
 def test_quadkey():
     tile = mercantile.Tile(486, 332, 10)


### PR DESCRIPTION
Otherwise the coordinate could get unintentionally clamped to the globe's extremeties:
https://github.com/mapbox/mercantile/blob/fe3762d14001ca400caf7462f59433b906fc25bd/mercantile/__init__.py#L533-L536

```python
>>> from math import nan
>>> max(nan, -180)
nan
>>> min(nan, 180)
nan
>>> max(-180, nan)
-180
>>> min(180, nan)
180
```