### PR TITLE
Update neighbors function across International Date Line

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -326,13 +326,18 @@ def neighbors(*tile, **kwargs):
 
     for i in [-1, 0, 1]:
         for j in [-1, 0, 1]:
+            n_xtile, n_ytile = xtile + i, ytile + j
             if i == 0 and j == 0:
                 continue
-            elif xtile + i < 0 or ytile + j < 0:
+            elif n_ytile < 0:
                 continue
-            elif xtile + i > hi or ytile + j > hi:
+            elif n_ytile > hi:
                 continue
-            tiles.append(Tile(x=xtile + i, y=ytile + j, z=ztile))
+            elif n_xtile < 0:
+                n_xtile = hi
+            elif n_xtile > hi:
+                n_xtile = 0
+            tiles.append(Tile(x=n_xtile, y=n_ytile, z=ztile))
 
     # Make sure to not generate invalid tiles for valid input
     # https://github.com/mapbox/mercantile/issues/122


### PR DESCRIPTION
In order to get tiles across the x International Date Line, this update will list the neighboring tiles across the 2**z and 0 divide.

The original version will not include tiles that are across the International Date Line (-180/180). 

- Previously `neighbors(Tile(0, 14, 9))` would create `[Tile(x=0, y=13, z=9),  Tile(x=0, y=15, z=9),  Tile(x=1, y=13, z=9),  Tile(x=1, y=14, z=9),  Tile(x=1, y=15, z=9)]`

In this code update, tiles that are at the International Date Line (-180/180) will create the neighboring Tile objects:

- `neighbours(Tile(0, 14, 9))` will create `[Tile(x=511, y=13, z=9), Tile(x=511, y=14, z=9), Tile(x=511, y=15, z=9), Tile(x=0, y=13, z=9), Tile(x=0, y=15, z=9), Tile(x=1, y=13, z=9), Tile(x=1, y=14, z=9), Tile(x=1, y=15, z=9)]`
- `neighbors(Tile(0,0,9))` will create `[Tile(x=511, y=0, z=9), Tile(x=511, y=1, z=9), Tile(x=0, y=1, z=9), Tile(x=1, y=0, z=9), Tile(x=1, y=1, z=9)]`

This change respects the y boundaries as not continuous, but expands the continuous nature of the x dimension. 