### PR TITLE
raise descriptive error when an invalid zoom level is provided

### DIFF
--- a/mercantile/__init__.py
+++ b/mercantile/__init__.py
@@ -58,6 +58,7 @@ RE = 6378137.0
 CE = 2 * math.pi * RE
 EPSILON = 1e-14
 LL_EPSILON = 1e-11
+MAX_ZOOM_LEVEL = int(math.log2(sys.float_info.max)) - 1
 
 
 class Tile(namedtuple("Tile", ["x", "y", "z"])):
@@ -190,6 +191,11 @@ def ul(*tile):
     """
     tile = _parse_tile_arg(*tile)
     xtile, ytile, zoom = tile
+    if zoom > MAX_ZOOM_LEVEL:
+        raise InvalidZoomError(
+            "zoom must be less than or equal to {}".format(MAX_ZOOM_LEVEL)
+        )
+
     Z2 = math.pow(2, zoom)
     lon_deg = xtile / Z2 * 360.0 - 180.0
     lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * ytile / Z2)))
@@ -212,6 +218,10 @@ def bounds(*tile):
     """
     tile = _parse_tile_arg(*tile)
     xtile, ytile, zoom = tile
+    if zoom > MAX_ZOOM_LEVEL:
+        raise InvalidZoomError(
+            "zoom must be less than or equal to {}".format(MAX_ZOOM_LEVEL)
+        )
 
     Z2 = math.pow(2, zoom)
 
@@ -367,6 +377,10 @@ def xy_bounds(*tile):
     """
     tile = _parse_tile_arg(*tile)
     xtile, ytile, zoom = tile
+    if zoom > MAX_ZOOM_LEVEL:
+        raise InvalidZoomError(
+            "zoom must be less than or equal to {}".format(MAX_ZOOM_LEVEL)
+        )
 
     tile_size = CE / math.pow(2, zoom)
 
@@ -413,6 +427,11 @@ def tile(lng, lat, zoom, truncate=False):
 
     """
     x, y = _xy(lng, lat, truncate=truncate)
+    if zoom > MAX_ZOOM_LEVEL:
+        raise InvalidZoomError(
+            "zoom must be less than or equal to {}".format(MAX_ZOOM_LEVEL)
+        )
+
     Z2 = math.pow(2, zoom)
 
     if x <= 0:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -112,6 +112,19 @@ def test_tile_truncate():
     )
 
 
+@pytest.mark.parametrize(
+    'func',
+    [mercantile.ul, mercantile.bounds, mercantile.xy_bounds, mercantile.tile]
+)
+def test_invalid_zoom_level_64_bit(func):
+    """Test that an error is raised when an invalid zoom level is provided."""
+    with pytest.raises(mercantile.InvalidZoomError) as exc_info:
+        func(3, 13, 1024)
+
+    err_msg, = exc_info.value.args
+    assert err_msg == 'zoom must be less than or equal to 1023'
+
+
 def test_tiles():
     bounds = (-105, 39.99, -104.99, 40)
     tiles = list(mercantile.tiles(*bounds, zooms=[14]))


### PR DESCRIPTION
currently an overflow error is raised which you probably never really want to blindly `except`. These functions are also used in terracotta to verify tiles exists (https://github.com/DHI/terracotta/issues/360) having a descriptive error (like already present in other cases) will help.

There is still a design decision whether to set a fixed limited (e.g. 28) or depend on the system maximum. The latter will be backwards compatible, who knows for what crazy zoom levels this is used :)